### PR TITLE
Fixed type check for validation warnings

### DIFF
--- a/library/HtmlValidator/Response.php
+++ b/library/HtmlValidator/Response.php
@@ -98,7 +98,7 @@ class Response {
 
             if ($message['type'] === 'error' || $message['type'] === 'non-document-error') {
                 $this->errors[] = $msg;
-            } else if ($message['type'] === 'info' && $message['subType'] === 'warning') {
+            } else if (isset($message['subType']) && $message['type'] === 'info' && $message['subType'] === 'warning') {
                 $this->warnings[] = $msg;
             }
         }

--- a/library/HtmlValidator/Response.php
+++ b/library/HtmlValidator/Response.php
@@ -98,7 +98,7 @@ class Response {
 
             if ($message['type'] === 'error' || $message['type'] === 'non-document-error') {
                 $this->errors[] = $msg;
-            } else if ($message['type'] === 'warning') {
+            } else if ($message['type'] === 'info' && $message['subType'] === 'warning') {
                 $this->warnings[] = $msg;
             }
         }

--- a/tests/UnitTests/ResponseTest.php
+++ b/tests/UnitTests/ResponseTest.php
@@ -151,7 +151,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
         $data = array(
             'messages' => array(
                 array(
-                    'type' => 'warning',
+                    'type' => 'info',
+                    'subType' => 'warning',
                     'firstLine' => 1,
                     'lastLine' => 2,
                     'firstColumn' => 3,
@@ -162,7 +163,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
                     'extract' => '<strong>Foo</strong>',
                 ),
                 array(
-                    'type' => 'warning',
+                    'type' => 'info',
+                    'subType' => 'warning',
                     'firstLine' => 9,
                     'lastLine' => 8,
                     'firstColumn' => 7,

--- a/tests/fixtures/document-valid-html4.html
+++ b/tests/fixtures/document-valid-html4.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">


### PR DESCRIPTION
The correct "type" for warnings in the response is 'info' and it has the "subType" 'warning'
https://github.com/validator/validator/wiki/Output:-JSON
