### PR TITLE
[fix] PHPDoc types

### DIFF
--- a/library/HtmlValidator/Message.php
+++ b/library/HtmlValidator/Message.php
@@ -221,7 +221,7 @@ class Message {
      *  (int)    $length - Length of substring to highlight
      *
      * @param callable $highlighter
-     * @return HtmlValidator\Message
+     * @return \HtmlValidator\Message
      */
     public function setHighlighter($highlighter) {
         if (!is_callable($highlighter)) {
@@ -237,7 +237,7 @@ class Message {
      * Default: "highlight"
      *
      * @param  string $className Valid CSS class name
-     * @return HtmlValidator\Message
+     * @return \HtmlValidator\Message
      */
     public function setHighlightClassName($className) {
         $this->highlightClassName = (string) $className;

--- a/library/HtmlValidator/NodeWrapper.php
+++ b/library/HtmlValidator/NodeWrapper.php
@@ -27,7 +27,7 @@ class NodeWrapper {
      * @param  string $parser  Parser name (HtmlValidator\Validator::PARSER_*)
      * @param  string $nodes   Nodes to wrap
      * @param  string $charset Charset to use
-     * @throws UnknownParserException If the given parser is not known
+     * @throws \HtmlValidator\Exception\UnknownParserException If the given parser is not known
      * @return string
      */
     public function wrap($parser, $nodes, $charset = null) {
@@ -42,7 +42,7 @@ class NodeWrapper {
             case Validator::PARSER_HTML4TR:
                 return $this->wrapInHtml4Document($nodes, $charset, $parser);
             default:
-                throw new UnknownParserException('Unknown parser "' . $parser . '"');
+                throw new Exception\UnknownParserException('Unknown parser "' . $parser . '"');
         }
     }
 

--- a/library/HtmlValidator/Response.php
+++ b/library/HtmlValidator/Response.php
@@ -27,28 +27,28 @@ class Response {
     /**
      * HTTP response
      *
-     * @var GuzzleHttp\Psr7\Response
+     * @var \GuzzleHttp\Psr7\Response
      */
     private $httpResponse;
 
     /**
      * List of errors encountered
      *
-     * @var array
+     * @var \HtmlValidator\Message[]
      */
     private $errors = array();
 
     /**
      * List of warnings encountered
      *
-     * @var array
+     * @var \HtmlValidator\Message[]
      */
     private $warnings = array();
 
     /**
      * List of all messages encountered
      *
-     * @var array
+     * @var \HtmlValidator\Message[]
      */
     private $messages = array();
 
@@ -137,7 +137,7 @@ class Response {
     /**
      * Returns all encountered errors
      *
-     * @return array
+     * @return \HtmlValidator\Message[]
      */
     public function getErrors() {
         return $this->errors;
@@ -146,7 +146,7 @@ class Response {
     /**
      * Returns all encountered warnings
      *
-     * @return array
+     * @return \HtmlValidator\Message[]
      */
     public function getWarnings() {
         return $this->warnings;
@@ -155,7 +155,7 @@ class Response {
     /**
      * Returns all encountered messages
      *
-     * @return array
+     * @return \HtmlValidator\Message[]
      */
     public function getMessages() {
         return $this->messages;

--- a/library/HtmlValidator/Validator.php
+++ b/library/HtmlValidator/Validator.php
@@ -86,7 +86,7 @@ class Validator {
     /**
      * Holds the HTTP client used to communicate with the API
      *
-     * @var GuzzleHttp\Client
+     * @var \GuzzleHttp\Client
      */
     private $httpClient;
 
@@ -107,12 +107,15 @@ class Validator {
     /**
      * Node wrapper tool
      *
-     * @var HtmlValidator\NodeWrapper
+     * @var \HtmlValidator\NodeWrapper
      */
     private $nodeWrapper;
 
     /**
      * Constructs a new validator instance
+     * @param string $validatorUrl
+     * @param string $parser
+     * @throws UnknownParserException
      */
     public function __construct($validatorUrl = self::DEFAULT_VALIDATOR_URL, $parser = self::PARSER_HTML5) {
         $this->httpClient = new HttpClient([
@@ -128,8 +131,8 @@ class Validator {
     /**
      * Set the HTTP client to use for requests
      *
-     * @param GuzzleHttp\ClientInterface $httpClient
-     * @return HttpValidator\Validator
+     * @param \GuzzleHttp\ClientInterface $httpClient
+     * @return \HtmlValidator\Validator
      */
     public function setHttpClient($httpClient) {
         $this->httpClient = $httpClient;
@@ -181,7 +184,7 @@ class Validator {
      * Set the charset to report to the validator
      *
      * @param string $charset Charset name (defaults to 'utf-8')
-     * @return HtmlValidator\Validator
+     * @return \HtmlValidator\Validator
      */
     public function setCharset($charset) {
         $this->defaultCharset = $charset;
@@ -226,7 +229,7 @@ class Validator {
      *
      * @param  string $document HTML/XML-document, as string
      * @param  string $charset  Charset to report (defaults to utf-8)
-     * @return HtmlValidator\Response
+     * @return \HtmlValidator\Response
      */
     public function validateDocument($document, $charset = null) {
         $document = (string) $document;
@@ -264,7 +267,7 @@ class Validator {
      *                        'checkErrorPages' - Set to true if you want to validate pages that
      *                        return status codes which is not in the 2xx range
      *
-     * @return HtmlValidator\Response
+     * @return \HtmlValidator\Response
      * @throws ServerException
      */
     public function validateUrl($url, $options = []) {
@@ -300,7 +303,7 @@ class Validator {
      *
      * @param  string $nodes   HTML/XML-chunk, as string
      * @param  string $charset Charset to report (defaults to configured client charset)
-     * @return HtmlValidator\Response
+     * @return \HtmlValidator\Response
      */
     public function validateNodes($nodes, $charset = null) {
         $wrapped = $this->nodeWrapper->wrap(
@@ -317,7 +320,7 @@ class Validator {
      *
      * @param  string $document HTML/XML-document, as string
      * @param  string $charset  Charset to report (defaults to configured client charset)
-     * @return HtmlValidator\Response
+     * @return \HtmlValidator\Response
      */
     public function validate($document, $charset = null) {
         return $this->validateDocument($document, $charset ?: $this->defaultCharset);

--- a/tests/UnitTests/MessageTest.php
+++ b/tests/UnitTests/MessageTest.php
@@ -18,16 +18,16 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     /**
      * Test construction and population of a message instance
      *
-     * @covers HtmlValidator\Message::__construct
-     * @covers HtmlValidator\Message::getType
-     * @covers HtmlValidator\Message::getFirstLine
-     * @covers HtmlValidator\Message::getLastLine
-     * @covers HtmlValidator\Message::getFirstColumn
-     * @covers HtmlValidator\Message::getLastColumn
-     * @covers HtmlValidator\Message::getHighlightStart
-     * @covers HtmlValidator\Message::getHighlightLength
-     * @covers HtmlValidator\Message::getText
-     * @covers HtmlValidator\Message::getExtract
+     * @covers \HtmlValidator\Message::__construct
+     * @covers \HtmlValidator\Message::getType
+     * @covers \HtmlValidator\Message::getFirstLine
+     * @covers \HtmlValidator\Message::getLastLine
+     * @covers \HtmlValidator\Message::getFirstColumn
+     * @covers \HtmlValidator\Message::getLastColumn
+     * @covers \HtmlValidator\Message::getHighlightStart
+     * @covers \HtmlValidator\Message::getHighlightLength
+     * @covers \HtmlValidator\Message::getText
+     * @covers \HtmlValidator\Message::getExtract
      */
     public function testCanPopulate() {
         $data = array(
@@ -57,8 +57,8 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure first line gets populated if not present in data set
      *
-     * @covers HtmlValidator\Message::__construct
-     * @covers HtmlValidator\Message::getFirstLine
+     * @covers \HtmlValidator\Message::__construct
+     * @covers \HtmlValidator\Message::getFirstLine
      */
     public function testPopulatesFirstLineDataIfNotPresent() {
         $data = array(
@@ -79,9 +79,9 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure proper plain-text formatting of message
      *
-     * @covers HtmlValidator\Message::__construct
-     * @covers HtmlValidator\Message::__toString
-     * @covers HtmlValidator\Message::format
+     * @covers \HtmlValidator\Message::__construct
+     * @covers \HtmlValidator\Message::__toString
+     * @covers \HtmlValidator\Message::format
      */
     public function testCorrectPlainTextFormatting() {
         $data = array(
@@ -119,10 +119,10 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure proper HTML formatting of message
      *
-     * @covers HtmlValidator\Message::__construct
-     * @covers HtmlValidator\Message::toHTML
-     * @covers HtmlValidator\Message::format
-     * @covers HtmlValidator\Message::highlight
+     * @covers \HtmlValidator\Message::__construct
+     * @covers \HtmlValidator\Message::toHTML
+     * @covers \HtmlValidator\Message::format
+     * @covers \HtmlValidator\Message::highlight
      */
     public function testCorrectHtmlFormatting() {
         $data = array(
@@ -148,11 +148,11 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure ability to specify custom css class name
      *
-     * @covers HtmlValidator\Message::__construct
-     * @covers HtmlValidator\Message::toHTML
-     * @covers HtmlValidator\Message::format
-     * @covers HtmlValidator\Message::highlight
-     * @covers HtmlValidator\Message::setHighlightClassName
+     * @covers \HtmlValidator\Message::__construct
+     * @covers \HtmlValidator\Message::toHTML
+     * @covers \HtmlValidator\Message::format
+     * @covers \HtmlValidator\Message::highlight
+     * @covers \HtmlValidator\Message::setHighlightClassName
      */
     public function testCanSetCustomCssClassNameForHighlighting() {
         $data = array(
@@ -179,10 +179,10 @@ class MessageTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure ability to specify custom highlighter
      *
-     * @covers HtmlValidator\Message::__construct
-     * @covers HtmlValidator\Message::toHTML
-     * @covers HtmlValidator\Message::format
-     * @covers HtmlValidator\Message::setHighlighter
+     * @covers \HtmlValidator\Message::__construct
+     * @covers \HtmlValidator\Message::toHTML
+     * @covers \HtmlValidator\Message::format
+     * @covers \HtmlValidator\Message::setHighlighter
      */
     public function testCanUseCustomHighlighter() {
         $data = array(

--- a/tests/UnitTests/NodeWrapperTest.php
+++ b/tests/UnitTests/NodeWrapperTest.php
@@ -46,8 +46,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the XML wrapper can wrap a single XML node correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInXmlDocument
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInXmlDocument
      */
     public function testWrapsSingleXmlNodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -72,8 +72,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the XML wrapper can wrap multiple XML nodes correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInXmlDocument
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInXmlDocument
      */
     public function testWrapsMultipleXmlNodesCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -101,8 +101,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the XML wrapper uses the passed charset
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInXmlDocument
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInXmlDocument
      */
     public function testWrapsXmlNodesInGivenCharset() {
         $document = new DOMDocument();
@@ -124,8 +124,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML5 wrapper can wrap a single HTML5 node correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml5Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml5Document
      */
     public function testWrapsSingleHtml5NodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -156,8 +156,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML5 wrapper can wrap multiple HTML5 nodes correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml5Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml5Document
      */
     public function testWrapsMultipleHtml5NodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -191,8 +191,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML5 wrapper uses the passed charset
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml5Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml5Document
      */
     public function testWrapsHtml5NodesInGivenCharset() {
         $wrapped = $this->wrapper->wrap(
@@ -217,8 +217,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML4 wrapper can wrap a single HTML4 node correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml4Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml4Document
      */
     public function testWrapsSingleHtml4NodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -250,8 +250,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML4 wrapper can wrap multiple HTML4 nodes correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml4Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml4Document
      */
     public function testWrapsMultipleHtml4NodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -286,8 +286,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML4 wrapper uses the passed charset
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml4Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml4Document
      */
     public function testWrapsHtml4NodesInGivenCharset() {
         $wrapped = $this->wrapper->wrap(
@@ -313,8 +313,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML4-TR wrapper can wrap a single HTML4 node correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml4Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml4Document
      */
     public function testWrapsSingleHtml4TrNodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -346,8 +346,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML4-TR wrapper can wrap multiple HTML4 nodes correctly
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml4Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml4Document
      */
     public function testWrapsMultipleHtml4TrNodeCorrectly() {
         $wrapped = $this->wrapper->wrap(
@@ -382,8 +382,8 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the HTML4-TR wrapper uses the passed charset
      *
-     * @covers HtmlValidator\NodeWrapper::wrap
-     * @covers HtmlValidator\NodeWrapper::wrapInHtml4Document
+     * @covers \HtmlValidator\NodeWrapper::wrap
+     * @covers \HtmlValidator\NodeWrapper::wrapInHtml4Document
      */
     public function testWrapsHtml4TrNodesInGivenCharset() {
         $wrapped = $this->wrapper->wrap(

--- a/tests/UnitTests/ResponseTest.php
+++ b/tests/UnitTests/ResponseTest.php
@@ -18,9 +18,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure construction of non-200 response throws ServerException
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @expectedException HtmlValidator\Exception\ServerException
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @expectedException \HtmlValidator\Exception\ServerException
      */
     public function testWillThrowOnNon200Reponse() {
         $responseMock = $this->getGuzzleResponseMock();
@@ -35,9 +35,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure construction of response with a non-JSON response throws ServerException
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @expectedException HtmlValidator\Exception\ServerException
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @expectedException \HtmlValidator\Exception\ServerException
      */
     public function testWillThrowOnNonJsonResponse() {
         $responseMock = $this->getGuzzleResponseMock();
@@ -58,9 +58,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure construction of response with an invalid JSON body throws ServerException
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @expectedException HtmlValidator\Exception\ServerException
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @expectedException \HtmlValidator\Exception\ServerException
      */
     public function testWillThrowOnInvalidJsonResponse() {
         $responseMock = $this->getGuzzleResponseMock();
@@ -86,11 +86,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure population of errors
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @covers HtmlValidator\Response::parse
-     * @covers HtmlValidator\Response::getErrors
-     * @covers HtmlValidator\Response::hasErrors
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @covers \HtmlValidator\Response::parse
+     * @covers \HtmlValidator\Response::getErrors
+     * @covers \HtmlValidator\Response::hasErrors
      */
     public function testWillPopulateErrors() {
         $data = [
@@ -138,11 +138,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure population of warnings
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @covers HtmlValidator\Response::parse
-     * @covers HtmlValidator\Response::getWarnings
-     * @covers HtmlValidator\Response::hasWarnings
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @covers \HtmlValidator\Response::parse
+     * @covers \HtmlValidator\Response::getWarnings
+     * @covers \HtmlValidator\Response::hasWarnings
      */
     public function testWillPopulateWarnings() {
         $data = array(
@@ -190,11 +190,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure population of messages
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @covers HtmlValidator\Response::parse
-     * @covers HtmlValidator\Response::getMessages
-     * @covers HtmlValidator\Response::hasMessages
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @covers \HtmlValidator\Response::parse
+     * @covers \HtmlValidator\Response::getMessages
+     * @covers \HtmlValidator\Response::hasMessages
      */
     public function testWillPopulateMessages() {
         $data = array(
@@ -254,12 +254,12 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
     /**
      * Test proper formatting of errors/warnings
      *
-     * @covers HtmlValidator\Response::__construct
-     * @covers HtmlValidator\Response::validateResponse
-     * @covers HtmlValidator\Response::parse
-     * @covers HtmlValidator\Response::format
-     * @covers HtmlValidator\Response::__toString
-     * @covers HtmlValidator\Response::toHTML
+     * @covers \HtmlValidator\Response::__construct
+     * @covers \HtmlValidator\Response::validateResponse
+     * @covers \HtmlValidator\Response::parse
+     * @covers \HtmlValidator\Response::format
+     * @covers \HtmlValidator\Response::__toString
+     * @covers \HtmlValidator\Response::toHTML
      */
     public function testWillFormat() {
         $data = array(
@@ -324,7 +324,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
      * Get a guzzle response mock
      *
      * @param  boolean $expectSuccess Whether to prepare the mock with the default expectations
-     * @return GuzzleHttp\Psr7\Response
+     * @return \GuzzleHttp\Psr7\Response
      */
     private function getGuzzleResponseMock($expectSuccess = false) {
         $mock = ($this->getMockBuilder('GuzzleHttp\Psr7\Response')

--- a/tests/UnitTests/ValidatorTest.php
+++ b/tests/UnitTests/ValidatorTest.php
@@ -18,7 +18,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure the client can be instantiated without errors with no arguments passed
      *
-     * @covers HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::__construct
      */
     public function testCanConstructClientWithDefaultArguments() {
         $client = new Validator();
@@ -28,9 +28,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Test that we can both set and get the parsers to be used when validating
      *
-     * @covers HtmlValidator\Validator::__construct
-     * @covers HtmlValidator\Validator::getParser
-     * @covers HtmlValidator\Validator::setParser
+     * @covers \HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::getParser
+     * @covers \HtmlValidator\Validator::setParser
      */
     public function testCanSetAndGetParsers() {
         $client = new Validator();
@@ -48,9 +48,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Test that we can both set and get the charset to be used when validating
      *
-     * @covers HtmlValidator\Validator::__construct
-     * @covers HtmlValidator\Validator::getCharset
-     * @covers HtmlValidator\Validator::setCharset
+     * @covers \HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::getCharset
+     * @covers \HtmlValidator\Validator::setCharset
      */
     public function testCanSetAndGetCharset() {
         $client = new Validator();
@@ -68,11 +68,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure that the validator sends the correct content type and charset for the parser given
      *
-     * @covers HtmlValidator\Validator::__construct
-     * @covers HtmlValidator\Validator::getCharset
-     * @covers HtmlValidator\Validator::setCharset
-     * @covers HtmlValidator\Validator::getContentTypeString
-     * @covers HtmlValidator\Validator::getMimeTypeForParser
+     * @covers \HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::getCharset
+     * @covers \HtmlValidator\Validator::setCharset
+     * @covers \HtmlValidator\Validator::getContentTypeString
+     * @covers \HtmlValidator\Validator::getMimeTypeForParser
      */
     public function testValidateDocumentSendsCorrectContentType() {
         $client = new Validator();
@@ -107,11 +107,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure that the validator sends the correct content type and charset for the parser given
      *
-     * @covers HtmlValidator\Validator::__construct
-     * @covers HtmlValidator\Validator::getCharset
-     * @covers HtmlValidator\Validator::setCharset
-     * @covers HtmlValidator\Validator::getContentTypeString
-     * @covers HtmlValidator\Validator::getMimeTypeForParser
+     * @covers \HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::getCharset
+     * @covers \HtmlValidator\Validator::setCharset
+     * @covers \HtmlValidator\Validator::getContentTypeString
+     * @covers \HtmlValidator\Validator::getMimeTypeForParser
      */
     public function testValidateDocumentSendsCorrectContentTypeWithExplicitCharset() {
         $client = new Validator();
@@ -146,13 +146,13 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure that the validate() method aliases validateDocument()
      *
-     * @covers HtmlValidator\Validator::__construct
-     * @covers HtmlValidator\Validator::getCharset
-     * @covers HtmlValidator\Validator::setCharset
-     * @covers HtmlValidator\Validator::getContentTypeString
-     * @covers HtmlValidator\Validator::getMimeTypeForParser
-     * @covers HtmlValidator\Validator::validateDocument
-     * @covers HtmlValidator\Validator::validate
+     * @covers \HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::getCharset
+     * @covers \HtmlValidator\Validator::setCharset
+     * @covers \HtmlValidator\Validator::getContentTypeString
+     * @covers \HtmlValidator\Validator::getMimeTypeForParser
+     * @covers \HtmlValidator\Validator::validateDocument
+     * @covers \HtmlValidator\Validator::validate
      */
     public function testValidateAliasesValidateDocument() {
         $client = new Validator();
@@ -187,11 +187,11 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Ensure that the validator sends the correct content type and charset for the parser given
      *
-     * @covers HtmlValidator\Validator::__construct
-     * @covers HtmlValidator\Validator::getCharset
-     * @covers HtmlValidator\Validator::setCharset
-     * @covers HtmlValidator\Validator::getContentTypeString
-     * @covers HtmlValidator\Validator::getMimeTypeForParser
+     * @covers \HtmlValidator\Validator::__construct
+     * @covers \HtmlValidator\Validator::getCharset
+     * @covers \HtmlValidator\Validator::setCharset
+     * @covers \HtmlValidator\Validator::getContentTypeString
+     * @covers \HtmlValidator\Validator::getMimeTypeForParser
      */
     public function testValidateNodesSendsCorrectRequest() {
         $client = new Validator();
@@ -227,7 +227,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
     /**
      * Get a mocked HTTP client
      *
-     * @return GuzzleHttp\Client
+     * @return \GuzzleHttp\Client
      */
     private function getHttpClientMock() {
         $mock = ($this->getMockBuilder('GuzzleHttp\Client')
@@ -242,7 +242,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
      * Get a guzzle response mock
      *
      * @param  mixed $body Request body
-     * @return GuzzleHttp\Psr7\Response
+     * @return \GuzzleHttp\Psr7\Response
      */
     private function getGuzzleResponseMock($body) {
         $mock = ($this->getMockBuilder('GuzzleHttp\Psr7\Response')


### PR DESCRIPTION
PHPStorm shows multiple warnings for type mismatch, for example:

```
Expected HtmlValidator\Response, got HtmlValidator\HtmlValidator\Response
```

![image](https://user-images.githubusercontent.com/16267156/48296627-291ade00-e4aa-11e8-9520-2da5fa9f9ba2.png)

This PR is intended to fix such issues. Besides, it provides a more detailed return type for arrays (describes array types).