### PR TITLE
[fix] add ext-dom for dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "guzzlehttp/guzzle": "^6.2.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.5.0"
+        "phpunit/phpunit": "^5.5.0",
+        "ext-dom": "*"
     },
     "support": {
         "issues": "https://github.com/rexxars/html-validator/issues"


### PR DESCRIPTION
Using `DOMDocument` in `/tests/UnitTests/NodeWrapperTest.php` requires `ext-dom` extension that was missing in the `composer.json`.