### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
     - develop
     - master
 before_script:
-    - composer -n --no-ansi install --dev --prefer-source
+    - composer -n --no-ansi install --prefer-source
     - cp phpunit.xml.travis phpunit.xml
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         "issues": "https://github.com/rexxars/html-validator/issues"
     },
     "autoload": {
-        "psr-0": {
-            "HtmlValidator": "library"
+        "psr-4": {
+            "HtmlValidator\\": "library/HtmlValidator"
         }
     }
 }

--- a/tests/IntegrationTests/ValidatorIntegrationTest.php
+++ b/tests/IntegrationTests/ValidatorIntegrationTest.php
@@ -10,12 +10,14 @@
 
 namespace HtmlValidator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class ValidatorIntegrationTest extends \PHPUnit_Framework_TestCase {
+class ValidatorIntegrationTest extends TestCase {
 
-    public function setUp() {
+    protected function setUp() {
         if (!HTML_VALIDATOR_ENABLE_INTEGRATION_TESTS) {
             $this->markTestSkipped('Integration tests disabled in configuration');
         }
@@ -107,8 +109,8 @@ class ValidatorIntegrationTest extends \PHPUnit_Framework_TestCase {
     public function testValidateUrl() {
         $validator = $this->getValidator();
         $response  = $validator->validateUrl('https://html-validator-fixtures.netlify.com/document-invalid-utf8-html5.html');
-        
-        $this->assertInstanceOf('\HtmlValidator\Response', $response);
+
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->hasErrors(), 'Invalid HTML5 should produce errors');
 
         // Can't guarantee order of messages, but assume this one won't go away
@@ -124,11 +126,11 @@ class ValidatorIntegrationTest extends \PHPUnit_Framework_TestCase {
         $validator = $this->getValidator();
         $response  = $validator->validateUrl('https://www.w3.org/404');
 
-        $this->assertInstanceOf('\HtmlValidator\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertTrue($response->hasErrors(), 'Invalid HTML5 should produce errors');
 
         $error = $response->getErrors()[0];
-        $this->assertTrue(strpos($error->getText(), '404') !== false);
+        $this->assertContains('404', $error->getText());
     }
 
     public function testValidateUrlWithAllowed404() {

--- a/tests/UnitTests/MessageTest.php
+++ b/tests/UnitTests/MessageTest.php
@@ -10,10 +10,12 @@
 
 namespace HtmlValidator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class MessageTest extends \PHPUnit_Framework_TestCase {
+class MessageTest extends TestCase {
 
     /**
      * Test construction and population of a message instance

--- a/tests/UnitTests/NodeWrapperTest.php
+++ b/tests/UnitTests/NodeWrapperTest.php
@@ -12,10 +12,12 @@ namespace HtmlValidator;
 
 use DOMDocument;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
+class NodeWrapperTest extends TestCase {
     /**
      * NodeWrapper instance
      *
@@ -143,7 +145,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
         // Ensure body tag has been inserted
         // (I know, regex and such: DOMDocument fails on meta charset tag)
         $this->assertSame(1, preg_match('/(<body[^>]*>.*<\/body>)/s', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         // Load the body into a DOMDocument
         $document = new DOMDocument();
@@ -176,7 +178,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
         // Ensure body tag has been inserted
         // (I know, regex and such: DOMDocument fails on meta charset tag)
         $this->assertSame(1, preg_match('/(<body[^>]*>.*<\/body>)/si', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         // Load the body into a DOMDocument
         $document = new DOMDocument();
@@ -209,7 +211,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
 
         // Expecting: <meta charset="iso-8859-1">
         $this->assertSame(1, preg_match('/<meta[^>]*charset=[\'"](.*?)[\'"]/i', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         $this->assertEquals('iso-8859-1', $groups[1]);
     }
@@ -240,7 +242,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
         // Ensure body tag has been inserted
         // (I know, regex and such: DOMDocument fails on meta charset tag)
         $this->assertSame(1, preg_match('/(<body[^>]*>.*<\/body>)/s', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         // Load the body into a DOMDocument
         $document = new DOMDocument();
@@ -274,7 +276,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
         // Ensure body tag has been inserted
         // (I know, regex and such: DOMDocument fails on meta charset tag)
         $this->assertSame(1, preg_match('/(<body[^>]*>.*<\/body>)/si', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         // Load the body into a DOMDocument
         $document = new DOMDocument();
@@ -307,7 +309,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
 
         // Expecting: <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
         $this->assertSame(1, preg_match('/<meta[^>]+charset=(.*?)[\'"]>/i', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         $this->assertEquals('iso-8859-1', $groups[1]);
     }
@@ -339,7 +341,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
         // Ensure body tag has been inserted
         // (I know, regex and such: DOMDocument fails on meta charset tag)
         $this->assertSame(1, preg_match('/(<body[^>]*>.*<\/body>)/s', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         // Load the body into a DOMDocument
         $document = new DOMDocument();
@@ -373,7 +375,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
         // Ensure body tag has been inserted
         // (I know, regex and such: DOMDocument fails on meta charset tag)
         $this->assertSame(1, preg_match('/(<body[^>]*>.*<\/body>)/si', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         // Load the body into a DOMDocument
         $document = new DOMDocument();
@@ -406,7 +408,7 @@ class NodeWrapperTest extends \PHPUnit_Framework_TestCase {
 
         // Expecting: <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
         $this->assertSame(1, preg_match('/<meta[^>]+charset=(.*?)[\'"]>/i', $wrapped, $groups));
-        $this->assertSame(2, count($groups));
+        $this->assertCount(2, $groups);
 
         $this->assertEquals('iso-8859-1', $groups[1]);
     }

--- a/tests/UnitTests/ResponseTest.php
+++ b/tests/UnitTests/ResponseTest.php
@@ -10,10 +10,12 @@
 
 namespace HtmlValidator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class ResponseTest extends \PHPUnit_Framework_TestCase {
+class ResponseTest extends TestCase {
 
     /**
      * Ensure construction of non-200 response throws ServerException
@@ -131,7 +133,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
         $errors = $response->getErrors();
         $this->assertTrue($response->hasErrors());
-        $this->assertSame(2, count($errors));
+        $this->assertCount(2, $errors);
         $this->assertSame($data['messages'][0]['message'], $errors[0]->getText());
         $this->assertSame($data['messages'][1]['message'], $errors[1]->getText());
     }
@@ -183,7 +185,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
         $warnings = $response->getWarnings();
         $this->assertTrue($response->hasWarnings());
-        $this->assertSame(2, count($warnings));
+        $this->assertCount(2, $warnings);
         $this->assertSame($data['messages'][0]['message'], $warnings[0]->getText());
         $this->assertSame($data['messages'][1]['message'], $warnings[1]->getText());
     }
@@ -246,7 +248,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase {
 
         $messages = $response->getMessages();
         $this->assertTrue($response->hasMessages());
-        $this->assertSame(3, count($messages));
+        $this->assertCount(3, $messages);
         $this->assertSame($data['messages'][0]['message'], $messages[0]->getText());
         $this->assertSame($data['messages'][1]['message'], $messages[1]->getText());
         $this->assertSame($data['messages'][2]['message'], $messages[2]->getText());

--- a/tests/UnitTests/ValidatorTest.php
+++ b/tests/UnitTests/ValidatorTest.php
@@ -10,10 +10,12 @@
 
 namespace HtmlValidator;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @author Espen Hovlandsdal <espen@hovlandsdal.com>
  */
-class ValidatorTest extends \PHPUnit_Framework_TestCase {
+class ValidatorTest extends TestCase {
 
     /**
      * Ensure the client can be instantiated without errors with no arguments passed
@@ -22,7 +24,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
      */
     public function testCanConstructClientWithDefaultArguments() {
         $client = new Validator();
-        $this->assertInstanceOf('HtmlValidator\Validator', $client);
+        $this->assertInstanceOf(Validator::class, $client);
     }
 
     /**
@@ -83,7 +85,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
         $document = '<p>Dat document</p>';
 
         $responseMock = $this->getGuzzleResponseMock(['messages' => []]);
-        
+
         $httpClientMock = $this->getHttpClientMock();
         $httpClientMock
             ->expects($this->once())
@@ -142,7 +144,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase {
                 ])
             )
             ->will($this->returnValue($responseMock));
-        
+
         $client->setCharset(Validator::CHARSET_ISO_8859_1);
         $client->setHttpClient($httpClientMock);
         $client->validateDocument($document);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,5 +16,4 @@ namespace HtmlValidator;
 
 define('FIXTURES_DIR', __DIR__ . '/fixtures');
 
-$autoloader = require __DIR__ . '/../vendor/autoload.php';
-$autoloader->add(__NAMESPACE__, __DIR__);
+require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
# Changed log
- To support latest stable PHPUnit version easily, using the `PHPUnit\Framework\TestCase\ namesapce.
- Removing the `--dev` option because this it's deprecated.

The deprecated warning message is as follows:
```
You are using the deprecated option "dev". Dev packages are installed by default now.
```
- Using the the `assertCount` to assert expected count is same as result.
- Using the `::class` to make class instance during `assertInstance` assertion.
- Removing unused namespace.
- Using the `require __DIR__ . '/../vendor/autoload.php';` directly on `bootstrap.php` and it will load required classes automatically.