### PR TITLE
Added sub type level warnings

### DIFF
--- a/library/HtmlValidator/Response.php
+++ b/library/HtmlValidator/Response.php
@@ -97,6 +97,9 @@ class Response {
         $data = json_decode($this->httpResponse->getBody(), true);
 
         foreach ($data['messages'] as $message) {
+            if ($message['type'] === 'info' && $message['subType'] === 'warning') {
+                $message['type'] = 'warning';
+            }
             $msg = new Message($message);
             $this->messages[] = $msg;
 


### PR DESCRIPTION
Hello,

The function `getWarnings()` always returns an empty array in my test-suite. I have the impression that all HTML warnings are returned by the API 'validator.nu' with 'type=info' and 'subType=warning'. So I have now added warnings at subtype level.